### PR TITLE
Add mode of interest to configs

### DIFF
--- a/configs/dev-emulator-program.nrel-op.json
+++ b/configs/dev-emulator-program.nrel-op.json
@@ -3,7 +3,9 @@
     "ts": 1655143472,
     "intro": {
         "program_or_study": "program",
-        "mode_studied": "E-bike",
+        "start_month": "9",
+        "start_year": "2020",
+        "mode_studied": "pilot_ebike",
         "program_admin_contact": "K. Shankari (k.shankari@nrel.gov)",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/dev-emulator-program.nrel-op.json
+++ b/configs/dev-emulator-program.nrel-op.json
@@ -5,7 +5,7 @@
         "program_or_study": "program",
         "start_month": "9",
         "start_year": "2020",
-        "mode_studied": "pilot_ebike",
+        "mode_studied": "e-bike",
         "program_admin_contact": "K. Shankari (k.shankari@nrel.gov)",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/dev-emulator-program.nrel-op.json
+++ b/configs/dev-emulator-program.nrel-op.json
@@ -3,6 +3,7 @@
     "ts": 1655143472,
     "intro": {
         "program_or_study": "program",
+        "mode_studied": "E-bike",
         "program_admin_contact": "K. Shankari (k.shankari@nrel.gov)",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/dev-emulator-study.nrel-op.json
+++ b/configs/dev-emulator-study.nrel-op.json
@@ -3,6 +3,8 @@
     "ts": 1655143472,
     "intro": {
         "program_or_study": "study",
+        "start_month": "9",
+        "start_year": "2020",
         "program_admin_contact": "K. Shankari (k.shankari@nrel.gov)",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/durham.nrel-op.json
+++ b/configs/durham.nrel-op.json
@@ -9,7 +9,7 @@
         "program_or_study": "program",
         "start_month": "8",
         "start_year": "2022",
-        "mode_studied": "pilot_ebike",
+        "mode_studied": "e-bike",
         "program_admin_contact": "waytogo@durhamnc.gov (waytogodurham.com/bullebike)",
         "deployment_partner_name": "City of Durham, North Carolina",
         "translated_text": {

--- a/configs/durham.nrel-op.json
+++ b/configs/durham.nrel-op.json
@@ -7,6 +7,7 @@
     },
     "intro": {
         "program_or_study": "program",
+        "mode_studied": "E-bike",
         "program_admin_contact": "waytogo@durhamnc.gov (waytogodurham.com/bullebike)",
         "deployment_partner_name": "City of Durham, North Carolina",
         "translated_text": {

--- a/configs/durham.nrel-op.json
+++ b/configs/durham.nrel-op.json
@@ -7,7 +7,9 @@
     },
     "intro": {
         "program_or_study": "program",
-        "mode_studied": "E-bike",
+        "start_month": "9",
+        "start_year": "2020",
+        "mode_studied": "pilot_ebike",
         "program_admin_contact": "waytogo@durhamnc.gov (waytogodurham.com/bullebike)",
         "deployment_partner_name": "City of Durham, North Carolina",
         "translated_text": {

--- a/configs/durham.nrel-op.json
+++ b/configs/durham.nrel-op.json
@@ -7,8 +7,8 @@
     },
     "intro": {
         "program_or_study": "program",
-        "start_month": "9",
-        "start_year": "2020",
+        "start_month": "8",
+        "start_year": "2022",
         "mode_studied": "pilot_ebike",
         "program_admin_contact": "waytogo@durhamnc.gov (waytogodurham.com/bullebike)",
         "deployment_partner_name": "City of Durham, North Carolina",

--- a/configs/mm-masscec.nrel-op.json
+++ b/configs/mm-masscec.nrel-op.json
@@ -8,7 +8,7 @@
     "intro": {
         "program_or_study": "program",
         "start_month": "9",
-        "start_year": "2020",
+        "start_year": "2022",
         "mode_studied": "pilot_ebike",
         "program_admin_contact": "info@ebikesforall.org, 617-491-7200",
         "deployment_partner_name": "Metro Mobility in partnership with MassCEC",

--- a/configs/mm-masscec.nrel-op.json
+++ b/configs/mm-masscec.nrel-op.json
@@ -7,6 +7,7 @@
     },
     "intro": {
         "program_or_study": "program",
+        "mode_studied": "E-bike",
         "program_admin_contact": "info@ebikesforall.org, 617-491-7200",
         "deployment_partner_name": "Metro Mobility in partnership with MassCEC",
         "translated_text": {

--- a/configs/mm-masscec.nrel-op.json
+++ b/configs/mm-masscec.nrel-op.json
@@ -9,7 +9,7 @@
         "program_or_study": "program",
         "start_month": "9",
         "start_year": "2022",
-        "mode_studied": "pilot_ebike",
+        "mode_studied": "e-bike",
         "program_admin_contact": "info@ebikesforall.org, 617-491-7200",
         "deployment_partner_name": "Metro Mobility in partnership with MassCEC",
         "translated_text": {

--- a/configs/mm-masscec.nrel-op.json
+++ b/configs/mm-masscec.nrel-op.json
@@ -7,7 +7,9 @@
     },
     "intro": {
         "program_or_study": "program",
-        "mode_studied": "E-bike",
+        "start_month": "9",
+        "start_year": "2020",
+        "mode_studied": "pilot_ebike",
         "program_admin_contact": "info@ebikesforall.org, 617-491-7200",
         "deployment_partner_name": "Metro Mobility in partnership with MassCEC",
         "translated_text": {

--- a/configs/nrel-commute.nrel-op.json
+++ b/configs/nrel-commute.nrel-op.json
@@ -7,6 +7,8 @@
     },
     "intro": {
         "program_or_study": "study",
+        "start_month": "9",
+        "start_year": "2020",
         "program_admin_contact": "Emily Kotz (emily.kotz@nrel.gov).",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/nrel-commute.nrel-op.json
+++ b/configs/nrel-commute.nrel-op.json
@@ -7,8 +7,8 @@
     },
     "intro": {
         "program_or_study": "study",
-        "start_month": "9",
-        "start_year": "2020",
+        "start_month": "8",
+        "start_year": "2022",
         "program_admin_contact": "Emily Kotz (emily.kotz@nrel.gov).",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/open-access.nrel-op.json
+++ b/configs/open-access.nrel-op.json
@@ -7,6 +7,8 @@
     },
     "intro": {
         "program_or_study": "study",
+        "start_month": "9",
+        "start_year": "2020",
         "program_admin_contact": "K. Shankari (k.shankari@nrel.gov)",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/open-access.nrel-op.json
+++ b/configs/open-access.nrel-op.json
@@ -7,8 +7,8 @@
     },
     "intro": {
         "program_or_study": "study",
-        "start_month": "9",
-        "start_year": "2020",
+        "start_month": "8",
+        "start_year": "2022",
         "program_admin_contact": "K. Shankari (k.shankari@nrel.gov)",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/stage-program.nrel-op.json
+++ b/configs/stage-program.nrel-op.json
@@ -7,6 +7,7 @@
     },
     "intro": {
         "program_or_study": "program",
+        "mode_studied": "E-bike",
         "program_admin_contact": "K. Shankari (k.shankari@nrel.gov)",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/stage-program.nrel-op.json
+++ b/configs/stage-program.nrel-op.json
@@ -7,7 +7,9 @@
     },
     "intro": {
         "program_or_study": "program",
-        "mode_studied": "E-bike",
+        "start_month": "9",
+        "start_year": "2020",
+        "mode_studied": "pilot_ebike",
         "program_admin_contact": "K. Shankari (k.shankari@nrel.gov)",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/stage-program.nrel-op.json
+++ b/configs/stage-program.nrel-op.json
@@ -9,7 +9,7 @@
         "program_or_study": "program",
         "start_month": "9",
         "start_year": "2020",
-        "mode_studied": "pilot_ebike",
+        "mode_studied": "e-bike",
         "program_admin_contact": "K. Shankari (k.shankari@nrel.gov)",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/stage-study.nrel-op.json
+++ b/configs/stage-study.nrel-op.json
@@ -7,6 +7,8 @@
     },
     "intro": {
         "program_or_study": "study",
+        "start_month": "9",
+        "start_year": "2020",
         "program_admin_contact": "K. Shankari (k.shankari@nrel.gov)",
         "deployment_partner_name": "National Renewable Energy Laboratory (NREL)",
         "translated_text": {

--- a/configs/wyoming.nrel-op.json
+++ b/configs/wyoming.nrel-op.json
@@ -9,7 +9,7 @@
         "program_or_study": "program",
         "start_month": "9",
         "start_year": "2022",
-        "mode_studied": "pilot_ebike",
+        "mode_studied": "e-bike",
         "program_admin_contact": "Alicia Cox at Yellowstone-Teton Clean Cities, alicia@ytcleancities.org, 810.955.5811",
         "deployment_partner_name": "Yellowstone-Teton Clean Cities",
         "translated_text": {

--- a/configs/wyoming.nrel-op.json
+++ b/configs/wyoming.nrel-op.json
@@ -8,7 +8,7 @@
     "intro": {
         "program_or_study": "program",
         "start_month": "9",
-        "start_year": "2020",
+        "start_year": "2022",
         "mode_studied": "pilot_ebike",
         "program_admin_contact": "Alicia Cox at Yellowstone-Teton Clean Cities, alicia@ytcleancities.org, 810.955.5811",
         "deployment_partner_name": "Yellowstone-Teton Clean Cities",

--- a/configs/wyoming.nrel-op.json
+++ b/configs/wyoming.nrel-op.json
@@ -7,6 +7,7 @@
     },
     "intro": {
         "program_or_study": "program",
+        "mode_studied": "E-bike",
         "program_admin_contact": "Alicia Cox at Yellowstone-Teton Clean Cities, alicia@ytcleancities.org, 810.955.5811",
         "deployment_partner_name": "Yellowstone-Teton Clean Cities",
         "translated_text": {

--- a/configs/wyoming.nrel-op.json
+++ b/configs/wyoming.nrel-op.json
@@ -7,7 +7,9 @@
     },
     "intro": {
         "program_or_study": "program",
-        "mode_studied": "E-bike",
+        "start_month": "9",
+        "start_year": "2020",
+        "mode_studied": "pilot_ebike",
         "program_admin_contact": "Alicia Cox at Yellowstone-Teton Clean Cities, alicia@ytcleancities.org, 810.955.5811",
         "deployment_partner_name": "Yellowstone-Teton Clean Cities",
         "translated_text": {


### PR DESCRIPTION
For each config, if it corresponds to a program then add the mode of interest as a parameter in the config file. This is used when running the program-specific visualization notebooks. For now, all of the programs are interested in ebikes, though this may change in future programs. For the testing configs, I also made the mode of interest ebike.