### PR TITLE
CASR: use short demo survey

### DIFF
--- a/configs/denver-casr.nrel-op.json
+++ b/configs/denver-casr.nrel-op.json
@@ -47,7 +47,7 @@
     "survey_info": {
       "surveys": {
         "UserProfileSurvey": {
-          "formPath": "json/demo-survey-v2.json",
+          "formPath": "json/demo-survey-short-v1.json",
           "version": 1,
           "compatibleWith": 1,
           "dataKey": "manual/demographic_survey",


### PR DESCRIPTION
With https://github.com/e-mission/e-mission-phone/pull/982, we can now use the shorter form of the demographics survey for CASR.