### PR TITLE
Make lo the default language for USAID-LAOS-EV

### DIFF
--- a/configs/usaid-laos-ev.nrel-op.json
+++ b/configs/usaid-laos-ev.nrel-op.json
@@ -44,7 +44,7 @@
           "dataKey": "manual/demographic_survey",
           "labelTemplate": {
             "en": "Answered",
-            "es": "Contestada"
+            "lo": "ຕອບ"
           }
         }
       },

--- a/configs/usaid-laos-ev.nrel-op.json
+++ b/configs/usaid-laos-ev.nrel-op.json
@@ -12,16 +12,6 @@
         "program_admin_contact": "Kosol.Kiatreungwattana@nrel.gov, 303-517-7674",
         "deployment_partner_name": "USAID - Laos",
         "translated_text": {
-            "en": {
-                "deployment_partner_name": "USAID - Laos",
-                "deployment_name": "USAID-NREL Support for Electric Vehicle Readiness",
-                "summary_line_1": "NREL supports Lao PDR in meeting its target of having 1% of vehicles on the road be electric by 2025 and 30% by 2030.",
-                "summary_line_2": "Meeting Lao EV adoption goals will require adequate EVSE deployment to meet consumer demand and provide confidence that sufficient charging options exist.",
-                "summary_line_3": "This app is used as a trip tracking solution for understanding travel behavior of vehicle usage.",
-                "short_textual_description": "For public electric vehicle supply equipment (EVSE) needs estimate for Lao PDR, NREL will model vehicle travel patterns, EV adoption, and future demand for public charging stations in Lao capital areas and strategically identify potential future EVSE needs and strategies for EVSE siting. NREL would use OPENPATH as a trip tracking solution for understanding travel behavior of vehicle usage.",
-                "why_we_collect": "NREL will use the data from OPENPATH and NREL EVI-Pro, electric vehicle infrastructure project tool to estimate how much electric vehicle (EV) charging infrastructure is needed in a designated area to meet a given demand.",
-                "research_questions": ["Travel behavior patterns to be used to model future EV adoption and infrastructure need to support the adoption.", "Data would be used with NREL EVI-Pro to estimate EVSE needed in a designated area."]
-            },
             "lo": {
                 "deployment_partner_name": "USAID - Laos",
                 "deployment_name": "ການຊ່ວຍເຫລືອທາງດ້ານວິຊາການເພື່ອກຽມຄວາມພ້ອມວຽກງານລົດໄຟຟ້າ ພາຍໄຕ້ການສະໝັບສະໜູນຂອງອົງການພັດທະນາສາກົນຂອງປະເທດສະຫະລັດອາເມລິກາ",
@@ -31,8 +21,17 @@
                 "short_textual_description": "ຄວາມຕ້ອງການສະຖານີສາກສາທາລະນະ ສໍາລັບ ສປປ ລາວ, ສະຖາບັນຄົ້ນຄ້ວາພະລັງງານທົດແທນ (NREL) ຈະສ້າງແບບຈໍາລອງຮູບແບບການເດີນທາງຂອງພາຫະນະ, ການຮອງຮັບລົດໄຟຟ້າ ແລະຄວາມຕ້ອງການສະຖານີສາກໄຟສາທາລະນະໃນອະນາຄົດ ຢູ່ ໃນຕົວເມືອງໃຫ່ຍ ຂອງ ສ ປປ ລາວ ແລະກໍານົດຍຸດທະສາດການຂະຫຍາຍສະຖານີສາກ ແລະ ພື້ນທີ່. ສະຖາບັນຄົ້ນຄ້ວາພະລັງງານທົດແທນ (NREL) ຈະນໍາໃຊ້ ລະບົບ (OPENPATH) ເພື່ອເປັນການເກັບກໍາ ແລະ ຕິດຕາມຂໍ້ມູນການເດີນທາງໃນການນໍາໃຊ້ພາຫະນະ.",
                 "why_we_collect": "ສະຖາບັນຄົ້ນຄ້ວາພະລັງງານທົດແທນ (NREL) ຈະນໍາໃຊ້ຂໍ້ມູນຈາກ OPENPATH ແລະ EVI-Pro ທີ່ເປັນເຄື່ອງມືຂັ້ນພື້ນຖານໃນການປະເມີນ ຄວາມຕ້ອງການການນໍາໃຊ້ ສະຖານີສາກໄຟລົດໄຟຟ້າ ເພື່ອເຮັດໃຫ້ການຂະຫຍາຍສະຖານີສາກສາມາດ ຕອບສະໜອງຄວາມຕ້ອງການຂອງຜູ້ນໍາໃຊ້ລົດໄຟຟ້າ.",
                 "research_questions": ["ຮູບແບບພຶດຕິກໍາການເດີນທາງທີ່ຈະນໍາໃຊ້ເພື່ອເປັນຮູບແບບໃນການຮອງຮັບລົດໄຟຟ້າໃນອະນາຄົດ ແລະ ໂຄງລ່າງພື້ນຖານຈໍາເປັນຕ້ອງສະຫນັບສະຫນູນໃນການນໍາໃຊ້ລົດໄຟຟ້າ.", "ຂໍ້ມູນຈະນໍາໃຊ້ ກັບລະບົບ EVI-Pro ຂອງສະຖາບັນຄົ້ນຄ້ວາພະລັງງານທົດແທນ (NREL) ເພື່ອຄາດຄະເນ ສະຖານີສາກ ທີ່ຕ້ອງການໃນພື້ນທີ່ ທີ່ກຳນົດໄວ້."]
+            },
+            "en": {
+                "deployment_partner_name": "USAID - Laos",
+                "deployment_name": "USAID-NREL Support for Electric Vehicle Readiness",
+                "summary_line_1": "NREL supports Lao PDR in meeting its target of having 1% of vehicles on the road be electric by 2025 and 30% by 2030.",
+                "summary_line_2": "Meeting Lao EV adoption goals will require adequate EVSE deployment to meet consumer demand and provide confidence that sufficient charging options exist.",
+                "summary_line_3": "This app is used as a trip tracking solution for understanding travel behavior of vehicle usage.",
+                "short_textual_description": "For public electric vehicle supply equipment (EVSE) needs estimate for Lao PDR, NREL will model vehicle travel patterns, EV adoption, and future demand for public charging stations in Lao capital areas and strategically identify potential future EVSE needs and strategies for EVSE siting. NREL would use OPENPATH as a trip tracking solution for understanding travel behavior of vehicle usage.",
+                "why_we_collect": "NREL will use the data from OPENPATH and NREL EVI-Pro, electric vehicle infrastructure project tool to estimate how much electric vehicle (EV) charging infrastructure is needed in a designated area to meet a given demand.",
+                "research_questions": ["Travel behavior patterns to be used to model future EV adoption and infrastructure need to support the adoption.", "Data would be used with NREL EVI-Pro to estimate EVSE needed in a designated area."]
             }
-
         }
     },
     "survey_info": {

--- a/configs/usaid-laos-ev.nrel-op.json
+++ b/configs/usaid-laos-ev.nrel-op.json
@@ -42,8 +42,8 @@
           "compatibleWith": 1,
           "dataKey": "manual/demographic_survey",
           "labelTemplate": {
-            "en": "Answered",
-            "lo": "ຕອບ"
+            "lo": "ຕອບ",
+            "en": "Answered"
           }
         }
       },


### PR DESCRIPTION
After recent updates to the join page, [nrel-openpath-join-page PR#18](https://github.com/e-mission/nrel-openpath-join-page/pull/18), the default language (and language options generally) for the join page are now configured dynamically, based on the deploy config file. In order to take advantage of this update, lo is now listed as the first language in the config for the usaid-laos-ev project. Therefore, the join page will show in Lao by default. 

I also noticed there was a place where "es: Contestada" was included, it has been changed to "lo: ຕອບ", since es is not supported by this study