### PR TITLE
Update Deployment Partner Name

### DIFF
--- a/configs/uue-openpath.nrel-op.json
+++ b/configs/uue-openpath.nrel-op.json
@@ -14,7 +14,7 @@
         "start_month": "08",
         "start_year": "2023",
         "program_admin_contact": "Gabriel Kreindler, Harvard (email: gkreindler@g.harvard.edu, phone: +1 857 284 9675).",
-        "deployment_partner_name": "Harvard",
+        "deployment_partner_name": "Busara/Harvard University",
         "translated_text": {
             "en": {
                 "deployment_partner_name": "Harvard",


### PR DESCRIPTION
After hearing back from the organizers of this study, we are able to update the name of the deployment partners based on their feedback. 