### PR TITLE
manually added the Key-Value pair ("data_trajectories_columns_exclude": ["user_id"]) to JSONs wherever admin_dashboard is present

### DIFF
--- a/configs/caeb-co.nrel-op.json
+++ b/configs/caeb-co.nrel-op.json
@@ -78,6 +78,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/ccebikes.nrel-op.json
+++ b/configs/ccebikes.nrel-op.json
@@ -84,6 +84,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/choose-your-ride.nrel-op.json
+++ b/configs/choose-your-ride.nrel-op.json
@@ -84,6 +84,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/cortezebikes.nrel-op.json
+++ b/configs/cortezebikes.nrel-op.json
@@ -84,6 +84,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/denver-casr.nrel-op.json
+++ b/configs/denver-casr.nrel-op.json
@@ -135,6 +135,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/durham.nrel-op.json
+++ b/configs/durham.nrel-op.json
@@ -61,6 +61,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/e-bikes-for-essentials.nrel-op.json
+++ b/configs/e-bikes-for-essentials.nrel-op.json
@@ -79,6 +79,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/ebikegj.nrel-op.json
+++ b/configs/ebikegj.nrel-op.json
@@ -84,6 +84,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/ebikethere-garfield-county.nrel-op.json
+++ b/configs/ebikethere-garfield-county.nrel-op.json
@@ -84,6 +84,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/fortmorgan.nrel-op.json
+++ b/configs/fortmorgan.nrel-op.json
@@ -82,6 +82,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/mm-masscec.nrel-op.json
+++ b/configs/mm-masscec.nrel-op.json
@@ -61,6 +61,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/nrel-commute.nrel-op.json
+++ b/configs/nrel-commute.nrel-op.json
@@ -52,6 +52,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/open-access.nrel-op.json
+++ b/configs/open-access.nrel-op.json
@@ -60,6 +60,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/ride2own.nrel-op.json
+++ b/configs/ride2own.nrel-op.json
@@ -71,6 +71,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/smart-commute-ebike.nrel-op.json
+++ b/configs/smart-commute-ebike.nrel-op.json
@@ -63,6 +63,7 @@
         "map_trip_lines": true,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/stage-timeuse.nrel-op.json
+++ b/configs/stage-timeuse.nrel-op.json
@@ -197,6 +197,7 @@
         "map_trip_lines": true,
         "push_send": true,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/usaid-laos-ev.nrel-op.json
+++ b/configs/usaid-laos-ev.nrel-op.json
@@ -77,6 +77,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/usaid-laos-ev.nrel-op.json
+++ b/configs/usaid-laos-ev.nrel-op.json
@@ -78,6 +78,5 @@
         "push_send": false,
         "options_uuids": true,
         "options_emails": true,
-        "data_trajectories_columns_exclude": ["user_id"]
     }
 }

--- a/configs/usaid-laos-ev.nrel-op.json
+++ b/configs/usaid-laos-ev.nrel-op.json
@@ -77,6 +77,6 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true,
+        "options_emails": true
     }
 }

--- a/configs/wyoming.nrel-op.json
+++ b/configs/wyoming.nrel-op.json
@@ -61,6 +61,7 @@
         "map_trip_lines": false,
         "push_send": false,
         "options_uuids": true,
-        "options_emails": true
+        "options_emails": true,
+        "data_trajectories_columns_exclude": ["user_id"]
     }
 }


### PR DESCRIPTION
1. Manually added  `"data_trajectories_columns_exclude": ["user_id"]` to JSON files which contain the `admin_dashboard` key. 
2. Ignored JSON files
    - `"ca-ebike.nrel-op.json"`
    - `"stage-program.nrel-op.json"`
    - `"stage-study.nrel-op.json"`
    - `"uprm-civic.nrel-op.json"`
    - `"uprm-nicr.nrel-op.json"`
    - `"usaid-laos-ev.nrel-op.json"`
    - `"uue.nrel-op.json"`
    - `"washingtoncommons.nrel-op.json"`
