### PR TITLE
Updates to Config Generation

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-new-config.yml
+++ b/.github/ISSUE_TEMPLATE/add-new-config.yml
@@ -510,7 +510,7 @@ body:
   id: admin_access
   attributes:
     label: Admin Access Emails
-    description: Please enter a comman separated list of emails to which we will grant access to the admin dashboard. This will usually be a relatively short list.
+    description: Please enter a comman separated list of emails to which we will grant access to the admin dashboard. [MAX 4]
   validations:
     required: true 
 # - type: dropdown

--- a/.github/ISSUE_TEMPLATE/add-new-config.yml
+++ b/.github/ISSUE_TEMPLATE/add-new-config.yml
@@ -510,7 +510,7 @@ body:
   id: admin_access
   attributes:
     label: Admin Access Emails
-    description: Please enter a comman separated list of emails to which we will grant access to the admin dashboard. [MAX 4]
+    description: Please enter a comman separated list of emails to which we will grant access to the admin dashboard. [MAX 5]
   validations:
     required: true 
 # - type: dropdown

--- a/.github/ISSUE_TEMPLATE/add-new-config.yml
+++ b/.github/ISSUE_TEMPLATE/add-new-config.yml
@@ -322,7 +322,7 @@ body:
   attributes:
     label: Custom Labels
     description: If you chose false above, and want drowdown style labeling, please provide the file name for your custom labels. You will need to submit a PR to add it to our repo - https://github.com/e-mission/nrel-openpath-deploy-configs/tree/main/label_options
-    placeholder: https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/label_options/example-program-label-options.json
+    placeholder: example-program-label-options.json
 
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/add-new-config.yml
+++ b/.github/ISSUE_TEMPLATE/add-new-config.yml
@@ -510,7 +510,7 @@ body:
   id: admin_access
   attributes:
     label: Admin Access Emails
-    description: Please enter a comman separated list of emails to which we will grant access to the admin dashboard. [MAX 5]
+    description: Please enter a comma separated list of emails to which we will grant access to the admin dashboard. [MAX 5]
   validations:
     required: true 
 # - type: dropdown

--- a/.github/actions/convertIssue/issue-to-json.js
+++ b/.github/actions/convertIssue/issue-to-json.js
@@ -41,6 +41,7 @@ export async function issueToJson() {
     await mkdir(outputDir, { recursive: true });
     
     let abbrevKey = getInput("hash-property-name");
+    abbrevKey = abbrevKey.toLowerCase();
     let fileName = getFileName(configData[ abbrevKey ]);
     await writeFile(path.join(outputDir, fileName), JSON.stringify(configData, null, 2));
   } catch (error) {

--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -141,12 +141,11 @@ function getSurveyInfo(dataObject) {
         },
       };
     } else {
-      let lower_url = dataObject.url_abbreviation.toLowerCase();
       surveyInfo.surveys = {
         UserProfileSurvey: {
           formPath:
             "https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/survey_resources/" +
-            lower_url+
+            dataObject.url_abbreviation+
             "/" +
             dataObject.custom_dem_survey_path,
           version: 1,
@@ -266,10 +265,13 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
   let bodyData = parseBodyData(body);
   let combinedObject = parseCombined(fields, bodyData);
 
+  // must be lower case
+  combinedObject.url_abbreviation = combinedObject.url_abbreviation.toLowerCase();
+
   //then compose the config object
   let configObject = {};
   try {
-    configObject["url_abbreviation"] = combinedObject.url_abbreviation.toLowerCase();
+    configObject["url_abbreviation"] = combinedObject.url_abbreviation;
     configObject["version"] = 1;
     configObject["ts"] = Date.now();
 

--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -353,7 +353,15 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
     }
 
     //list of administrator emails
-    configObject['admin_dashboard'].admin_access = combinedObject.admin_access.split(',');
+    admin_list = combinedObject.admin_access.split(',');
+    if (admin_list.length > 4){
+      setFailed("sorry, admin access is limited to a maximum of 4 emails, please shorten your list of emails"); 
+    }
+    // leading/trailing whitespace will lead to errors
+    for (let i = 0; i < admin_list.length; i++) {
+      admin_list[i] = admin_list[i].strip();
+    }
+    configObject['admin_dashboard'].admin_access = admin_list;
 
     //TODO: add handling for custom reminder schemes
 

--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -353,15 +353,15 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
     }
 
     //list of administrator emails
-    admin_list = combinedObject.admin_access.split(',');
-    if (admin_list.length > 4){
+    let email_list = combinedObject.admin_access.split(',');
+    if (email_list.length > 4){
       setFailed("sorry, admin access is limited to a maximum of 4 emails, please shorten your list of emails"); 
     }
     // leading/trailing whitespace will lead to errors
-    for (let i = 0; i < admin_list.length; i++) {
-      admin_list[i] = admin_list[i].strip();
+    for (let i = 0; i < email_list.length; i++) {
+      email_list[i] = email_list[i].strip();
     }
-    configObject['admin_dashboard'].admin_access = admin_list;
+    configObject['admin_dashboard'].admin_access = email_list;
 
     //TODO: add handling for custom reminder schemes
 

--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -359,7 +359,7 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
     }
     // leading/trailing whitespace will lead to errors
     for (let i = 0; i < email_list.length; i++) {
-      email_list[i] = email_list[i].strip();
+      email_list[i] = email_list[i].trim();
     }
     configObject['admin_dashboard'].admin_access = email_list;
 

--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -354,8 +354,8 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
 
     //list of administrator emails
     let email_list = combinedObject.admin_access.split(',');
-    if (email_list.length > 4){
-      setFailed("sorry, admin access is limited to a maximum of 4 emails, please shorten your list of emails"); 
+    if (email_list.length > 5){
+      setFailed("sorry, admin access is limited to a maximum of 5 emails, please shorten your list of emails"); 
     }
     // leading/trailing whitespace will lead to errors
     for (let i = 0; i < email_list.length; i++) {

--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -141,11 +141,12 @@ function getSurveyInfo(dataObject) {
         },
       };
     } else {
+      let lower_url = dataObject.url_abbreviation.toLowerCase();
       surveyInfo.surveys = {
         UserProfileSurvey: {
           formPath:
             "https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/survey_resources/" +
-            dataObject.url_abbreviation +
+            lower_url+
             "/" +
             dataObject.custom_dem_survey_path,
           version: 1,
@@ -268,7 +269,7 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
   //then compose the config object
   let configObject = {};
   try {
-    configObject["url_abbreviation"] = combinedObject.url_abbreviation;
+    configObject["url_abbreviation"] = combinedObject.url_abbreviation.toLowerCase();
     configObject["version"] = 1;
     configObject["ts"] = Date.now();
 

--- a/.github/workflows/issue-to-json.yml
+++ b/.github/workflows/issue-to-json.yml
@@ -43,6 +43,8 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v5
         with:
+          add-paths: |
+            configs/
           commit-message: Create or update a new config file
           signoff: false
           branch: new-config

--- a/.github/workflows/issue-to-json.yml
+++ b/.github/workflows/issue-to-json.yml
@@ -47,9 +47,9 @@ jobs:
             configs/
           commit-message: Create or update a new config file
           signoff: false
-          branch: new-config
+          branch: new-config-#${{ env.IssueNumber }}
           delete-branch: false
-          title: '[Config] create new file'
+          title: '[Config #${{ env.IssueNumber }}] create new file'
           body: |
             Adding a new config file
             - Initialized by creating or updating the coressponding issue


### PR DESCRIPTION
In testing before our demo today, I realized that the workflow was still committing `node-modules` to the PR branch.

I recognized that this was happening in the pull-request-generation step of the workflow, and looked into the documentation for that process.

I needed to specify an 'add-path' parameter to restrict the tracked changes to the `configs` folder.

I plan to go back and see if there are any other review comments from previous iterations that I can also address here. 