### PR TITLE
Functionality to remove users from AWS User Pool

### DIFF
--- a/configs/wyoming.nrel-op.json
+++ b/configs/wyoming.nrel-op.json
@@ -44,7 +44,6 @@
         "trip_end_notification": false
     },
     "admin_dashboard": {
-
         "overview_users": true,
         "overview_active_users": true,
         "overview_trips": true,

--- a/configs/wyoming.nrel-op.json
+++ b/configs/wyoming.nrel-op.json
@@ -44,6 +44,7 @@
         "trip_end_notification": false
     },
     "admin_dashboard": {
+
         "overview_users": true,
         "overview_active_users": true,
         "overview_trips": true,


### PR DESCRIPTION
**This PR is a continuation of e-mission/e-mission-docs#1008**

Copying the following from [comment](https://github.com/e-mission/nrel-openpath-deploy-configs/pull/45#issuecomment-1921856200) in #45:

I added functionality to remove users who are not in the config file, but are already in the user pool. Previously, I created the `user_already_exists` function:

```
def user_already_exists(pool_id, email, cognito_client):
    try:
        response = cognito_client.list_users(UserPoolId=pool_id)
        users = response["Users"]
        result = False
        if str(users).find(email) > 1:
            result = True
        return result
    except ClientError as err:
        logger.error(
            "Couldn't list users for %s. Here's why: %s: %s",
            pool_id,
            err.response["Error"]["Code"],
            err.response["Error"]["Message"],
        )
        raise
```
this function takes `users`, which is a list of dictionaries containing info on each user in the pool, and searches for a string matching the desired email. 

For the new use case, I modified it a bit to create `get_users`:

```
def get_users(pool_id, cognito_client):
    try:
        response = cognito_client.list_users(UserPoolId=pool_id)
        return response["Users"]
    except ClientError as err:
        logger.error(
            "Couldn't list users for %s. Here's why: %s: %s",
            pool_id,
            err.response["Error"]["Code"],
            err.response["Error"]["Message"],
        )
        raise
```
This function is called early on in the program, and gives us the `users` variable:
`users = get_users(pool_id, cognito_client)`

Next, each dictionary in `users` is looped over, and the email is isolated as `user_email`. 
```
    for user in users:
        for attr_dict in user["Attributes"]:
            if attr_dict["Name"] == "email":
                user_email = attr_dict["Value"]
                if user_email not in emails:
                    remove_user(pool_id, user_email)
                    print(f"{user_email} removed from pool.")
```
If the `user_email` is not in the `emails` list that was pulled from the config file, another new function named `remove_user` is called:


```
def remove_user(pool_id, user):
    response = cognito_client.admin_delete_user(
        UserPoolId= pool_id,
        Username= str(user)
)
```

I tested this by adding myself to the pool:
```
email1@nrel.gov not in user pool! Creating account...
Account created! Sending welcome email.
```

Then trying to re-add myself AND another new email,
```
email1@nrel.gov already in user pool!
email2@yahoo.com not in user pool! Creating account...
Account created! Sending welcome email.
```

And finally, removing my first email from the config to see what happens:

```
email1@nrel.gov removed from pool.
email2@yahoo.com already in user pool!
```
I checked the user pool, and my email1@nrel.gov was indeed removed from the pool! I decided to try and follow the welcome email to log in with my removed email, just to see what would happen. I got the following message:
<img width="466" alt="Screenshot 2024-01-31 at 11 20 25 PM" src="https://github.com/e-mission/nrel-openpath-deploy-configs/assets/90212258/eb59ad04-ab4a-46f7-ac86-a1ed24bb24b5">