### PR TITLE
🚫 Fix "connectURL" bug in GitHub Action - Correct "connectURL" key to "connectUrl"

### DIFF
--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -278,7 +278,7 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
     let connect_url =
       "https://" + combinedObject.url_abbreviation + "-openpath.nrel.gov/api/";
     configObject["server"] = {
-      connectURL: connect_url,
+      connectUrl: connect_url,
       aggregate_call_auth: "user_only",
     }; //TODO check options for call + add to form?
 

--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -282,7 +282,13 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
       aggregate_call_auth: "user_only",
     }; //TODO check options for call + add to form?
 
-    let subgroups = combinedObject.subgroups.split(",");
+    let subgroups = combinedObject.subgroups.split(",").map(item => item.trim());
+    if (!subgroups.includes("test")) {
+      subgroups.push("test");
+    }
+    if (!subgroups.includes("default")) {
+      subgroups.push("default");
+    }
     configObject["opcode"] = {
       autogen: cleanBoolean(combinedObject.autogen),
       subgroups: subgroups,

--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -283,11 +283,8 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
     }; //TODO check options for call + add to form?
 
     let subgroups = combinedObject.subgroups.split(",").map(item => item.trim());
-    if (!subgroups.includes("test")) {
-      subgroups.push("test");
-    }
-    if (!subgroups.includes("default")) {
-      subgroups.push("default");
+    if (subgroups.length == 1 && subgroups[0] == "") {
+      subgroups = ["default", "test"];
     }
     configObject["opcode"] = {
       autogen: cleanBoolean(combinedObject.autogen),


### PR DESCRIPTION
The problem that we experienced with the github workflow when @shankari  and Jianli found when testing `doee-electricbike-proj` was that the field connectURL had capitalized URL, when it's supposed to be read into e-mission-phone as connectUrl. This minor change fixes that problem!

Thanks to @Abby-Wheelis for the help in understanding github workflows!

Testing: See my test GitHub workflow automated issue (tested in my forked repo)
https://github.com/sebastianbarry/nrel-openpath-deploy-configs/issues/2
(Actual result of the change in:
https://github.com/sebastianbarry/nrel-openpath-deploy-configs/commit/a4fbfc06ec867d4aaebb5a719748355534a57590)