### PR TITLE
Adding "admin_access" key

### DIFF
--- a/configs/usaid-laos-ev.nrel-op.json
+++ b/configs/usaid-laos-ev.nrel-op.json
@@ -61,6 +61,7 @@
         "trip_end_notification": false
     },
     "admin_dashboard": {
+        "admin_access": ["K.Shankari@nrel.gov", "awheelis@nrel.gov", "sebastian.barry@nrel.gov", "Sanjini.Nanayakkara@nrel.gov", "Kosol.Kiatreungwattana@nrel.gov", "Dustin.Weigl@nrel.gov"],
         "overview_users": true,
         "overview_active_users": true,
         "overview_trips": true,


### PR DESCRIPTION
Since we are actively working on the laos project and potentially modifying the config, adding the admin_access section can prevent accidental removal of users from the pool.