### PR TITLE
`dfc-fermata`: Update "showsIf" conditions to use bracket notation

### DIFF
--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -69,17 +69,17 @@
         {
           "surveyName": "DfcGasTrip",
           "not-filled-in-label": { "en": "Gas Car Survey" },
-          "showsIf": "sections[0].sensed_mode_str == 'CAR'"
+          "showsIf": "sections[0]['sensed_mode_str'] == 'CAR'"
         },
         {
           "surveyName": "DfcEvRoamingTrip",
           "not-filled-in-label": { "en": "EV Survey" },
-          "showsIf": "sections[0].sensed_mode_str != 'CAR' && !pointIsWithinBounds(end_loc.coordinates, [[-105.153, 39.745], [-105.150, 39.743]])"
+          "showsIf": "sections[0]['sensed_mode_str'] != 'CAR' && !pointIsWithinBounds(end_loc['coordinates'], [[-105.153, 39.745], [-105.150, 39.743]])"
         },
         {
           "surveyName": "DfcEvReturnTrip",
           "not-filled-in-label": { "en": "EV Survey" },
-          "showsIf": "sections[0].sensed_mode_str != 'CAR' && pointIsWithinBounds(end_loc.coordinates, [[-105.153, 39.745], [-105.150, 39.743]])"
+          "showsIf": "sections[0]['sensed_mode_str'] != 'CAR' && pointIsWithinBounds(end_loc['coordinates'], [[-105.153, 39.745], [-105.150, 39.743]])"
         }
       ]
     },


### PR DESCRIPTION
We should use bracket notation for these expressions because it works with both JS objects and Python dicts https://github.com/e-mission/e-mission-docs/issues/1051#issuecomment-2033313273