### PR TITLE
Add vehicles + beacon fields to `dfc-fermata` for next week's demo

### DIFF
--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -102,6 +102,74 @@
         "color": "red",
         "engine": "ICE"
       }
+    },
+    {
+      "value": "car_abbys_prius",
+      "bluetooth_major_minor": ["dfc0:fff1"],
+      "name": "Abby's Prius",
+      "baseMode": "CAR",
+      "met_equivalent": "IN_VEHICLE",
+      "kgCo2PerKm": 0.22031,
+      "vehicle_info": {
+        "type": "car",
+        "license": "ABI 1234",
+        "make": "Toyota",
+        "model": "Prius",
+        "year": 2011,
+        "color": "silver",
+        "engine": "HEV"
+      }
+    },
+    {
+      "value": "ecar_gsa_leaf1",
+      "bluetooth_major_minor": ["dfc0:fff2"],
+      "name": "GSA Leaf 1",
+      "baseMode": "E_CAR",
+      "met_equivalent": "IN_VEHICLE",
+      "kgCo2PerKm": 0.08216,
+      "vehicle_info": {
+        "type": "car",
+        "license": "??? ????",
+        "make": "Nissan",
+        "model": "Leaf",
+        "year": 0,
+        "color": "???",
+        "engine": "BEV"
+      }
+    },
+    {
+      "value": "ecar_gsa_leaf2",
+      "bluetooth_major_minor": ["dfc0:fff3"],
+      "name": "GSA Leaf 2",
+      "baseMode": "E_CAR",
+      "met_equivalent": "IN_VEHICLE",
+      "kgCo2PerKm": 0.08216,
+      "vehicle_info": {
+        "type": "car",
+        "license": "??? ????",
+        "make": "Nissan",
+        "model": "Leaf",
+        "year": 0,
+        "color": "???",
+        "engine": "BEV"
+      }
+    },
+    {
+      "value": "ecar_gsa_pacifica",
+      "bluetooth_major_minor": ["dfc0:fff4"],
+      "name": "GSA Pacifica",
+      "baseMode": "E_CAR",
+      "met_equivalent": "IN_VEHICLE",
+      "kgCo2PerKm": 0.127,
+      "vehicle_info": {
+        "type": "car",
+        "license": "??? ????",
+        "make": "Chrysler",
+        "model": "Pacifica",
+        "year": 0,
+        "color": "???",
+        "engine": "PHEV"
+      }
     }
   ],
   "tracking": {

--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -85,6 +85,28 @@
     },
     "trip-labels": "ENKETO"
   },
+  "vehicle_identities": [
+    {
+      "value": "car_jacks_mazda3",
+      "bluetooth_major_minor": ["dfc0:fff0"],
+      "name": "Jack's Mazda 3",
+      "baseMode":"CAR",
+      "met_equivalent":"IN_VEHICLE",
+      "kgCo2PerKm": 0.22031,
+      "vehicle_info": {
+        "type": "car",
+        "license": "JHK ****",
+        "make": "Mazda",
+        "model": "3",
+        "year": 2014,
+        "color": "red",
+        "engine": "ICE"
+      }
+    }
+  ],
+  "tracking": {
+    "bluetooth_only": true
+  },
   "display_config": {
     "use_imperial": true
   },

--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -89,7 +89,7 @@
     {
       "value": "car_jacks_mazda3",
       "bluetooth_major_minor": ["dfc0:fff0"],
-      "name": "Jack's Mazda 3",
+      "text": "Jack's Mazda 3",
       "baseMode":"CAR",
       "met_equivalent":"IN_VEHICLE",
       "kgCo2PerKm": 0.22031,
@@ -106,7 +106,7 @@
     {
       "value": "car_abbys_prius",
       "bluetooth_major_minor": ["dfc0:fff1"],
-      "name": "Abby's Prius",
+      "text": "Abby's Prius",
       "baseMode": "CAR",
       "met_equivalent": "IN_VEHICLE",
       "kgCo2PerKm": 0.22031,
@@ -123,7 +123,7 @@
     {
       "value": "ecar_gsa_leaf1",
       "bluetooth_major_minor": ["dfc0:fff2"],
-      "name": "GSA Leaf 1",
+      "text": "GSA Leaf 1",
       "baseMode": "E_CAR",
       "met_equivalent": "IN_VEHICLE",
       "kgCo2PerKm": 0.08216,
@@ -140,7 +140,7 @@
     {
       "value": "ecar_gsa_leaf2",
       "bluetooth_major_minor": ["dfc0:fff3"],
-      "name": "GSA Leaf 2",
+      "text": "GSA Leaf 2",
       "baseMode": "E_CAR",
       "met_equivalent": "IN_VEHICLE",
       "kgCo2PerKm": 0.08216,
@@ -157,7 +157,7 @@
     {
       "value": "ecar_gsa_pacifica",
       "bluetooth_major_minor": ["dfc0:fff4"],
-      "name": "GSA Pacifica",
+      "text": "GSA Pacifica",
       "baseMode": "E_CAR",
       "met_equivalent": "IN_VEHICLE",
       "kgCo2PerKm": 0.127,

--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -1,6 +1,6 @@
 {
   "url_abbreviation": "dfc-fermata",
-  "version": 1,
+  "version": 2,
   "ts": 1707714796485,
   "server": {
     "connectUrl": "https://dfc-fermata-openpath.nrel.gov/api/",


### PR DESCRIPTION
Adds 2 fields to the dynamic config (as described in https://github.com/e-mission/e-mission-docs/issues/1062)

For vehicle identities, I have only added 1 so far: my own car with the Accent beacon I have in my possession. I will configure this beacon with the UUID described here https://github.com/e-mission/e-mission-data-collection/pull/220#issuecomment-2046190565; and with the major and minor values I put in the config ("dfc0:fff0") Will add others' vehicles once I have that information.

Also sets "tracking" . "bluetooth_only" to true, to signify that we will not track trips unless one of these vehicles is recognized.