### PR TITLE
Add partner to admin dashboard

### DIFF
--- a/configs/usaid-laos-ev.nrel-op.json
+++ b/configs/usaid-laos-ev.nrel-op.json
@@ -61,7 +61,7 @@
         "trip_end_notification": false
     },
     "admin_dashboard": {
-        "admin_access": ["K.Shankari@nrel.gov", "awheelis@nrel.gov", "sebastian.barry@nrel.gov", "Sanjini.Nanayakkara@nrel.gov", "Kosol.Kiatreungwattana@nrel.gov", "Dustin.Weigl@nrel.gov"],
+        "admin_access": ["K.Shankari@nrel.gov", "awheelis@nrel.gov", "sebastian.barry@nrel.gov", "Sanjini.Nanayakkara@nrel.gov", "Kosol.Kiatreungwattana@nrel.gov", "Dustin.Weigl@nrel.gov", "thythavysiphachanh@gmail.com"],
         "overview_users": true,
         "overview_active_users": true,
         "overview_trips": true,


### PR DESCRIPTION
Based on meeting last night, Sing needs admin access to verify labeling for a user and award them the incentive

Sangini also probably needs another new account, as she is still locked out

I mentioned to both of them that they should activate their accounts as soon as they can after receiving the email, as the temporary password will expire

