### PR TITLE
DFC Fleet Vehicle Updates

### DIFF
--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -1,6 +1,6 @@
 {
   "url_abbreviation": "dfc-fermata",
-  "version": 2,
+  "version": 3,
   "ts": 1707714796485,
   "server": {
     "connectUrl": "https://dfc-fermata-openpath.nrel.gov/api/",
@@ -69,17 +69,17 @@
         {
           "surveyName": "DfcGasTrip",
           "not-filled-in-label": { "en": "Gas Car Survey" },
-          "showsIf": "sections[0]['sensed_mode_str'] == 'CAR'"
+          "showsIf": "confirmedMode?.baseMode == 'CAR'"
         },
         {
           "surveyName": "DfcEvRoamingTrip",
           "not-filled-in-label": { "en": "EV Survey" },
-          "showsIf": "sections[0]['sensed_mode_str'] != 'CAR' && !pointIsWithinBounds(end_loc['coordinates'], [[-105.153, 39.745], [-105.150, 39.743]])"
+          "showsIf": "confirmedMode?.baseMode == 'E_CAR' && !pointIsWithinBounds(end_loc['coordinates'], [[-105.118, 39.719], [-105.115, 39.717]])"
         },
         {
           "surveyName": "DfcEvReturnTrip",
           "not-filled-in-label": { "en": "EV Survey" },
-          "showsIf": "sections[0]['sensed_mode_str'] != 'CAR' && pointIsWithinBounds(end_loc['coordinates'], [[-105.153, 39.745], [-105.150, 39.743]])"
+          "showsIf": "confirmedMode?.baseMode == 'E_CAR' && pointIsWithinBounds(end_loc['coordinates'], [[-105.118, 39.719], [-105.115, 39.717]])"
         }
       ]
     },

--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -169,8 +169,9 @@
         "year": 0,
         "color": "black",
         "engine": "PHEV"
-      },
-      {
+      }
+    },
+    {
       "value": "ecar_gsa_bolt",
       "bluetooth_major_minor": ["dfc0:fff5"],
       "text": "GSA Bolt",

--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -129,11 +129,11 @@
       "kgCo2PerKm": 0.08216,
       "vehicle_info": {
         "type": "car",
-        "license": "??? ????",
+        "license": "G13 1991Z",
         "make": "Nissan",
         "model": "Leaf",
         "year": 0,
-        "color": "???",
+        "color": "silver",
         "engine": "BEV"
       }
     },
@@ -146,11 +146,11 @@
       "kgCo2PerKm": 0.08216,
       "vehicle_info": {
         "type": "car",
-        "license": "??? ????",
+        "license": "G13 1992Z",
         "make": "Nissan",
         "model": "Leaf",
         "year": 0,
-        "color": "???",
+        "color": "silver",
         "engine": "BEV"
       }
     },
@@ -163,12 +163,28 @@
       "kgCo2PerKm": 0.127,
       "vehicle_info": {
         "type": "car",
-        "license": "??? ????",
+        "license": "G41 4259Z",
         "make": "Chrysler",
         "model": "Pacifica",
         "year": 0,
-        "color": "???",
+        "color": "black",
         "engine": "PHEV"
+      },
+      {
+      "value": "ecar_gsa_bolt",
+      "bluetooth_major_minor": ["dfc0:fff5"],
+      "text": "GSA Bolt",
+      "baseMode": "E_CAR",
+      "met_equivalent": "IN_VEHICLE",
+      "kgCo2PerKm":0.08216,
+      "vehicle_info": {
+        "type": "car",
+        "license": "G13 1361W",
+        "make": "Chrysler",
+        "model": "Pacifica",
+        "year": 0,
+        "color": "silver",
+        "engine": "BEV"
       }
     }
   ],


### PR DESCRIPTION
This morning, we received updates to the plate #s and colors of the vehicles being tested by the fleet. I think they're taking the two leafs and the vans on the test trips this week, but will reprogram beacons on site if need be. 