### PR TITLE
Add second location for testing `DfcEvReturnTrip`

### DIFF
--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -1,6 +1,6 @@
 {
   "url_abbreviation": "dfc-fermata",
-  "version": 6,
+  "version": 7,
   "ts": 1707714796485,
   "server": {
     "connectUrl": "https://dfc-fermata-openpath.nrel.gov/api/",
@@ -72,14 +72,14 @@
           "showsIf": "confirmedMode?.baseMode == 'CAR'"
         },
         {
-          "surveyName": "DfcEvRoamingTrip",
-          "not-filled-in-label": { "en": "EV Survey" },
-          "showsIf": "confirmedMode?.baseMode == 'E_CAR' && !pointIsWithinBounds(end_loc['coordinates'], [[-105.118, 39.719], [-105.115, 39.717]])"
-        },
-        {
           "surveyName": "DfcEvReturnTrip",
           "not-filled-in-label": { "en": "EV Survey" },
-          "showsIf": "confirmedMode?.baseMode == 'E_CAR' && pointIsWithinBounds(end_loc['coordinates'], [[-105.118, 39.719], [-105.115, 39.717]])"
+          "showsIf": "confirmedMode?.baseMode == 'E_CAR' && (pointIsWithinBounds(end_loc['coordinates'], [[-105.118, 39.719], [-105.115, 39.717]]) || pointIsWithinBounds(end_loc['coordinates'], [[-105.13, 39.853], [-105.11, 39.847]]))"
+        },
+        {
+          "surveyName": "DfcEvRoamingTrip",
+          "not-filled-in-label": { "en": "EV Survey" },
+          "showsIf": "confirmedMode?.baseMode == 'E_CAR'"
         }
       ]
     },


### PR DESCRIPTION
Now the DfcEvReturnTrip will show if the BLE mode is E_CAR and the end location is inside either of these two boxes.

Also, since these surveys are read in order and the matched survey is the first one whose condition matches, we can treat this like an if / else if block. I reordered DfcEvReturnTrip before DfcEvRoamingTrip so we don't have to specifically say `!pointIsWithinBounds(...)` on DfcEvRoamingTrip, making these conditions slightly less verbose.