### PR TITLE
Update admin emails, add `find_emails` script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.DS_Store
 .vscode/settings.json

--- a/configs/cortezebikes.nrel-op.json
+++ b/configs/cortezebikes.nrel-op.json
@@ -16,7 +16,7 @@
         "start_month": "06",
         "start_year": "2023",
         "mode_studied": "e-bike",
-        "program_admin_contact": "Elijah Fenton: elijah@fourcore.org. 4CORE office: 970-259-1916.",
+        "program_admin_contact": "4CORE office: 970-259-1916.",
         "deployment_partner_name": "Four Corners Office for Resource Efficiency (4CORE)",
         "translated_text": {
             "en": {

--- a/configs/ride2own.nrel-op.json
+++ b/configs/ride2own.nrel-op.json
@@ -54,7 +54,7 @@
         "trip_end_notification": false
     },
     "admin_dashboard": {
-        "admin_access": ["griffin@weallrisegroup.com", "henry@thestreettrust.org", "burgin@thestreettrust.org", "quincy@weallrisegroup.com", "madi@thestreettrust.org", "sophie@thestreettrust.org", "k.shankari@nrel.gov"],
+        "admin_access": ["burgin@thestreettrust.org", "quincy@weallrisegroup.com", "madi@thestreettrust.org", "sophie@thestreettrust.org", "k.shankari@nrel.gov"],
         "overview_users": true,
         "overview_active_users": true,
         "overview_trips": true,

--- a/configs/usaid-laos-ev.nrel-op.json
+++ b/configs/usaid-laos-ev.nrel-op.json
@@ -61,7 +61,7 @@
         "trip_end_notification": false
     },
     "admin_dashboard": {
-        "admin_access": ["K.Shankari@nrel.gov", "awheelis@nrel.gov", "sebastian.barry@nrel.gov", "Sanjini.Nanayakkara@nrel.gov", "Kosol.Kiatreungwattana@nrel.gov", "Dustin.Weigl@nrel.gov", "thythavysiphachanh@gmail.com", "bonnie.powell@nrel.gov", "Kevin.Xue@nrel.gov"],
+        "admin_access": ["K.Shankari@nrel.gov", "awheelis@nrel.gov", "Jack.Greenlee@nrel.gov", "Sanjini.Nanayakkara@nrel.gov", "Kosol.Kiatreungwattana@nrel.gov", "thythavysiphachanh@gmail.com", "bonnie.powell@nrel.gov", "Kevin.Xue@nrel.gov"],
         "overview_users": true,
         "overview_active_users": true,
         "overview_trips": true,

--- a/scripts/find_emails.py
+++ b/scripts/find_emails.py
@@ -1,0 +1,31 @@
+# prints a comma-separated list of all email addresses found in the program configs
+
+import os
+import re
+
+# get a list of all programs from the configs directory
+programs = os.listdir('configs')
+
+# or, specify programs manually:
+# programs = [
+#     'denver-casr.nrel-op.json',
+#     'nrel-commute.nrel-op.json',
+#     'open-access.nrel-op.json',
+#     'ride2own.nrel-op.json',
+#     'smart-commute-ebike.nrel-op.json',
+#     # ...
+# ]
+
+print('Checking %d programs for email addresses...\n' % len(programs))
+
+emails = []
+for program in programs:
+    with open('configs/'+program, 'r') as f:
+        emails_for_program = re.findall(r'[\w.+-]+@[\w-]+\.[\w.-]+', f.read())
+        emails_for_program = [e.rstrip(' .,') for e in emails_for_program]
+        print(program + ' has emails: ' + str(emails_for_program))
+        emails.extend(emails_for_program)
+
+emails = list(set([e.lower() for e in emails]))
+print('\nIn total, found ' + str(len(emails)) + ' emails:')
+print(', '.join(emails))


### PR DESCRIPTION
### remove emails of people who have left their respective organizations

For cortezebikes, I removed the outdated email (I did not add a new email since the main collection period is over)
For ride2own, we have enough other representatives from We All Rise and the The Street Trust, so I did not add anyone else.
For usaid-laos, I added myself to replace the outdated NREL emails.

### add the find_emails script

This iterates through all configs (or a subset of configs if listed), and prints the email address contained within those configs. Useful for sending emails to all program admins.

### add .DS_Store to .gitignore