### PR TITLE
fix typos and string/bool issues with `admin_dashboard.token_generate`

### DIFF
--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -333,7 +333,7 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
       ),
       //unlikely to not be nrelop, could require manual changes
       token_prefix: "nrelop",
-      toekn_generate: combinedObject.autogen, //want to match the autogen above
+      token_generate: configObject['opcode']['autogen'], //want to match the autogen above
     };
 
     //list of all the boolean values in the admin dashboard section, add to issue template and list for new value

--- a/configs/4core-ebike.nrel-op.json
+++ b/configs/4core-ebike.nrel-op.json
@@ -81,7 +81,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "toekn_generate": "true",
+    "token_generate": true,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/cosa-ebike-project.nrel-op.json
+++ b/configs/cosa-ebike-project.nrel-op.json
@@ -81,7 +81,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "toekn_generate": "true",
+    "token_generate": true,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -433,7 +433,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "token_generate": "false",
+    "token_generate": false,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/doee-electricbike-proj.nrel-op.json
+++ b/configs/doee-electricbike-proj.nrel-op.json
@@ -84,7 +84,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "toekn_generate": "true",
+    "token_generate": true,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/godcgo.nrel-op.json
+++ b/configs/godcgo.nrel-op.json
@@ -82,7 +82,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "toekn_generate": "true",
+    "token_generate": true,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/nc-transit-equity-study.nrel-op.json
+++ b/configs/nc-transit-equity-study.nrel-op.json
@@ -81,7 +81,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "toekn_generate": "false",
+    "token_generate": false,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/r2ohillsboro.nrel-op.json
+++ b/configs/r2ohillsboro.nrel-op.json
@@ -67,7 +67,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "toekn_generate": "true",
+    "token_generate": true,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/r2omilwaukie.nrel-op.json
+++ b/configs/r2omilwaukie.nrel-op.json
@@ -67,7 +67,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "toekn_generate": "true",
+    "token_generate": true,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/r2oparkrose.nrel-op.json
+++ b/configs/r2oparkrose.nrel-op.json
@@ -67,7 +67,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "toekn_generate": "true",
+    "token_generate": true,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/sm-ebike.nrel-op.json
+++ b/configs/sm-ebike.nrel-op.json
@@ -75,7 +75,7 @@
     "data_uuids_columns_exclude": [],
     "data_trajectories_columns_exclude": [],
     "token_prefix": "nrelop",
-    "token_generate": "false",
+    "token_generate": false,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/stm-community.nrel-op.json
+++ b/configs/stm-community.nrel-op.json
@@ -76,7 +76,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "toekn_generate": "true",
+    "token_generate": true,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/unc-ebike.nrel-op.json
+++ b/configs/unc-ebike.nrel-op.json
@@ -81,7 +81,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "token_generate": "false",
+    "token_generate": false,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,

--- a/configs/uw-prs.nrel-op.json
+++ b/configs/uw-prs.nrel-op.json
@@ -84,7 +84,7 @@
     "additional_trip_columns": [],
     "data_uuids_columns_exclude": [],
     "token_prefix": "nrelop",
-    "toekn_generate": "true",
+    "token_generate": true,
     "overview_users": true,
     "overview_active_users": true,
     "overview_trips": true,


### PR DESCRIPTION
When I was meeting with sm-ebike, I saw that their admin dashboard had the Tokens page enabled. To my surprise, I looked at their config and saw `"token_generate": "false"`

Then I realized it should be `false` with no quotes. A string containing the word `"false"` evaluates as a truthy value, causing the Tokens page to show up.

Looking further I realized there are actually 2 issues going on here. A lot of other programs have it misspelled as `toekn_generate`, which is because of a typo in `parse-issue-body.js`

So in `parse-issue-body.js` I fixed both the typo and the string/boolean mixup, then I manually fixed all the affected configs.