### PR TITLE
fix: use seconds for autocreated configs "ts"

### DIFF
--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -273,7 +273,7 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
   try {
     configObject["url_abbreviation"] = combinedObject.url_abbreviation;
     configObject["version"] = 1;
-    configObject["ts"] = Date.now();
+    configObject["ts"] = Math.floor(Date.now() / 1000);
 
     let connect_url =
       "https://" + combinedObject.url_abbreviation + "-openpath.nrel.gov/api/";

--- a/configs/4core-ebike.nrel-op.json
+++ b/configs/4core-ebike.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "4core-ebike",
   "version": 1,
-  "ts": 1719435689601,
+  "ts": 1719435689,
   "server": {
     "connectUrl": "https://4core-ebike-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/cosa-ebike-project.nrel-op.json
+++ b/configs/cosa-ebike-project.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "cosa-ebike-project",
   "version": 1,
-  "ts": 1710526862150,
+  "ts": 1710526862,
   "server": {
     "connectUrl": "https://cosa-ebike-project-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "dfc-fermata",
   "version": 9,
-  "ts": 1707714796485,
+  "ts": 1707714796,
   "server": {
     "connectUrl": "https://dfc-fermata-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/doee-electricbike-proj.nrel-op.json
+++ b/configs/doee-electricbike-proj.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "doee-electricbike-proj",
   "version": 1,
-  "ts": 1707330356754,
+  "ts": 1707330356,
   "server": {
     "connectUrl": "https://doee-electricbike-proj-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/godcgo.nrel-op.json
+++ b/configs/godcgo.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "godcgo",
   "version": 1,
-  "ts": 1714679651512,
+  "ts": 1714679651,
   "server": {
     "connectUrl": "https://godcgo-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/nc-transit-equity-study.nrel-op.json
+++ b/configs/nc-transit-equity-study.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "nc-transit-equity-study",
   "version": 1,
-  "ts": 1733948731794,
+  "ts": 1733948731,
   "server": {
     "connectUrl": "https://nc-transit-equity-study-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/r2ohillsboro.nrel-op.json
+++ b/configs/r2ohillsboro.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "r2ohillsboro",
   "version": 1,
-  "ts": 1714080477080,
+  "ts": 1714080477,
   "server": {
     "connectUrl": "https://r2ohillsboro-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/r2omilwaukie.nrel-op.json
+++ b/configs/r2omilwaukie.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "r2omilwaukie",
   "version": 1,
-  "ts": 1714080442042,
+  "ts": 1714080442,
   "server": {
     "connectUrl": "https://r2omilwaukie-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/r2oparkrose.nrel-op.json
+++ b/configs/r2oparkrose.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "r2oparkrose",
   "version": 1,
-  "ts": 1714080310835,
+  "ts": 1714080310,
   "server": {
     "connectUrl": "https://r2oparkrose-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/sm-ebike.nrel-op.json
+++ b/configs/sm-ebike.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "sm-ebike",
   "version": 1,
-  "ts": 1728422892858,
+  "ts": 1728422892,
   "server": {
     "connectUrl": "https://sm-ebike-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/stm-community.nrel-op.json
+++ b/configs/stm-community.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "stm-community",
   "version": 1,
-  "ts": 1720645300402,
+  "ts": 1720645300,
   "server": {
     "connectUrl": "https://stm-community-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/unc-ebike.nrel-op.json
+++ b/configs/unc-ebike.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "unc-ebike",
   "version": 3,
-  "ts": 1730230434000,
+  "ts": 1730230434,
   "server": {
     "connectUrl": "https://unc-ebike-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"

--- a/configs/uw-prs.nrel-op.json
+++ b/configs/uw-prs.nrel-op.json
@@ -1,7 +1,7 @@
 {
   "url_abbreviation": "uw-prs",
   "version": 1,
-  "ts": 1707503923100,
+  "ts": 1707503923,
   "server": {
     "connectUrl": "https://uw-prs-openpath.nrel.gov/api/",
     "aggregate_call_auth": "user_only"


### PR DESCRIPTION
I noticed this inconsistency between older (manually created) configs and newer (created from the issue template) configs; it's because Date.now() returns milliseconds