### PR TITLE
Updates to New Project Configuration Form

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-new-config.yml
+++ b/.github/ISSUE_TEMPLATE/add-new-config.yml
@@ -13,7 +13,10 @@ body:
   id: url_abbreviation
   attributes:
     label: Shortened Name
-    description: This will become part of the url for your deployment's join page - could be an abbreviation, or along the lines of open-access-study.
+    description: |
+      Please enter an abbreviated handle for your project. This will be used in the URL for your join page.
+      Keep this under 15 characters, using lowercase letters, hyphens, and/or numbers.
+      e.g. "open-access"
   validations:
     required: true
 - type: dropdown
@@ -47,7 +50,10 @@ body:
   id: subgroups
   attributes: 
     label: OPcode Subgroups
-    description: Please enter a list separated by commas.
+    description: |
+      If you want to categorize users into subgroups, please provide a comma-separated list of subgroups.
+      Use lowercase letters, hyphens, and/or numbers. (e.g. "test, group-1, group-2")
+      Leave this blank for "test" and "default" subgroups.
     placeholder: test, default
   validations: 
     required: false
@@ -55,7 +61,7 @@ body:
   id: start
   attributes:
     label: Start Month
-    description: Month and year of project start
+    description: Month and year of project start (MM/YYYY)
     placeholder: 01/2024
   validations:
     required: true
@@ -331,7 +337,9 @@ body:
   id: default_reminders
   attributes:
     label: Use default reminder schedule?
-    description: 
+    description: |
+      By default, we will send daily notifications reminding users to label trips if they have recent unlabeled trips.
+      If you choose "false", you can describe a custom reminder schedule below.
     default: 0
     options:  
       - "true"

--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -333,7 +333,7 @@ export async function parseIssueBody(githubIssueTemplateFile, body) {
       ),
       //unlikely to not be nrelop, could require manual changes
       token_prefix: "nrelop",
-      token_generate: configObject['opcode']['autogen'], //want to match the autogen above
+      token_generate: !configObject['opcode']['autogen'], // only for pregen tokens
     };
 
     //list of all the boolean values in the admin dashboard section, add to issue template and list for new value


### PR DESCRIPTION
- add more detailed descriptions for fields that have requirements, like url_abbreviation being lowercase, numbers, or hyphens and < 15 characters
- description for default reminder scheme
- token_generate should only be true for pregen tokens (autogen=false)