### PR TITLE
[unc-ebike] add w2 and w2test subgroups

### DIFF
--- a/configs/unc-ebike.nrel-op.json
+++ b/configs/unc-ebike.nrel-op.json
@@ -10,7 +10,9 @@
     "autogen": false,
     "subgroups": [
       "test",
-      "default"
+      "default",
+      "w2test",
+      "w2"
     ],
     "suspended_subgroups": [
       "default",


### PR DESCRIPTION
This adds our Wave 2 subgroups to the UNC e-bike OpenPATH configuration. We plan to start Wave 2 data collection soon, and are using new opcodes and leaving the original opcodes suspended to ensure all participants reconsent to Wave 2.