### PR TITLE
[unc-ebike] suspend w2 and w2test

### DIFF
--- a/configs/unc-ebike.nrel-op.json
+++ b/configs/unc-ebike.nrel-op.json
@@ -16,7 +16,9 @@
         ],
         "suspended_subgroups": [
             "default",
-            "test"
+            "test",
+            "w2",
+            "w2test"
         ]
     },
     "intro": {


### PR DESCRIPTION
We have completed our wave 2 data collection, so this suspends the w2 and w2test subgroups.