### PR TITLE
✨ define deployment-level overrides on native configs: tracking, sync

### DIFF
--- a/configs/dfc-fermata.nrel-op.json
+++ b/configs/dfc-fermata.nrel-op.json
@@ -1,6 +1,6 @@
 {
     "url_abbreviation": "dfc-fermata",
-    "version": 9,
+    "version": 10,
     "ts": 1707714796,
     "server": {
         "connectUrl": "https://dfc-fermata-openpath.nrel.gov/api/",
@@ -443,7 +443,7 @@
         }
     ],
     "tracking": {
-        "bluetooth_only": true
+        "is_fleet": true
     },
     "display_config": {
         "use_imperial": true

--- a/configs/walk-study-psu.nrel-op.json
+++ b/configs/walk-study-psu.nrel-op.json
@@ -1,6 +1,6 @@
 {
     "url_abbreviation": "walk-study-psu",
-    "version": 3,
+    "version": 4,
     "ts": 1741122104,
     "server": {
         "connectUrl": "https://walk-study-psu-openpath.nrel.gov/api/",
@@ -61,6 +61,9 @@
             }
         },
         "trip-labels": "ENKETO"
+    },
+    "tracking": {
+        "filter_distance": -1
     },
     "display_config": {
         "use_imperial": true

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,9 +15,8 @@ export type DeploymentConfig = {
   label_options?: `https://${string}`;
   vehicle_identities?: VehicleIdentity[];
   reminderSchemes?: ReminderSchemesConfig;
-  tracking?: {
-    bluetooth_only: boolean;
-  };
+  tracking?: Partial<TrackingConfig>;
+  sync?: Partial<SyncConfig>;
   display_config: {
     use_imperial: boolean;
   };
@@ -115,6 +114,27 @@ export type ReminderSchemesConfig = {
     text?: { [lang: string]: string };
     defaultTime?: string; // format is HH:MM in 24 hour time
   };
+};
+
+// corresponds to LocationTrackingConfig in e-mission-data-collection
+export type TrackingConfig = {
+  is_duty_cycling: boolean;
+  simulate_user_interaction: boolean;
+  accuracy: number;
+  accuracy_threshold: number;
+  filter_distance: number;
+  filter_time: number;
+  geofence_radius: number;
+  ios_use_visit_notifications_for_detection: boolean;
+  ios_use_remote_push_for_sync: boolean;
+  android_geofence_responsiveness: number;
+  is_fleet: boolean;
+};
+
+// corresponds to ServerSyncConfig in cordova-server-sync
+export type SyncConfig = {
+  sync_interval: number; // seconds
+  ios_use_remote_push: boolean;
 };
 
 // the available metrics that can be displayed in the phone dashboard

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "nrel-openpath-deploy-configs",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Some behaviors of the native code are configurable via the "tracking" config and "sync" config. Defaults are set in the native code (i.e. app level) and users can edit in Profile > Developer Zone, but up to now they have not been set at the deployment level. For the fleet version of OpenPATH, we did add support for one deployment-level config option under "tracking" ("bluetooth_only" which mapped to "isFleet" in the native code) but it was handled separately from other options.

We are reworking the native code so that *any* fields defined in "tracking" or "sync" override the built-in default values when that config is constructed. This brings the deployment config spec in line with the native code spec and should simplify the config logic in the process.