### PR TITLE
Update ca-ebike.nrel-op.json

### DIFF
--- a/configs/ca-ebike.nrel-op.json
+++ b/configs/ca-ebike.nrel-op.json
@@ -82,10 +82,7 @@
         "overview_trips_trend": true,
         "data_uuids": true,
         "data_trips": true,
-        "data_trips_columns_exclude": [
-            "data.start_loc.coordinates",
-            "data.end_loc.coordinates"
-        ],
+        "data_trips_columns_exclude": [],
         "additional_trip_columns": [],
         "data_uuids_columns_exclude": [],
         "token_generate": false,

--- a/configs/ca-ebike.nrel-op.json
+++ b/configs/ca-ebike.nrel-op.json
@@ -1,5 +1,5 @@
 {
-    "version": 1,
+    "version": 2,
     "ts": 1655143472,
     "server": {
         "connectUrl": "https://ca-ebike-openpath.nrel.gov/api/",


### PR DESCRIPTION
remove the lat and long fields in the "data_trips_columns_exclude". We have IRB approval to store "travel locations".