### PR TITLE
✨ Support inline label_options config and add types

### DIFF
--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -19,13 +19,14 @@ jobs:
         with:
           node-version: '18'
 
+      - name: Install dependencies
+        run: |
+          npm install typescript-json-schema ajv-cli
+
       - name: Generate JSON schema with typescript-json-schema
         run: |
-          npm install -g typescript-json-schema
           npx typescript-json-schema index.d.ts DeploymentConfig --noExtraProps --required --out config.schema.json
 
-      - name: Validate all configs against config.schema.json
-        uses: cardinalby/schema-validator-action@v3
-        with:
-          file: 'configs/*.json'
-          schema: 'config.schema.json'
+      - name: Validate all configs with ajv-cli
+        run: |
+          npx ajv validate -s config.schema.json -d "configs/*.json"

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ export type DeploymentConfig = {
     surveys: EnketoSurveyConfig;
     buttons?: SurveyButtonsConfig;
   };
-  label_options?: `https://${string}`;
+  label_options?: LabelOptionsConfig | `https://${string}`;
   vehicle_identities?: VehicleIdentity[];
   reminderSchemes?: ReminderSchemesConfig;
   tracking?: Partial<TrackingConfig>;
@@ -84,6 +84,53 @@ export type SurveyButtonsConfig = {
     | SurveyButtonConfig
     | SurveyButtonConfig[];
 };
+
+/* BEGIN: label_options types */
+
+export type FootprintFuelType =
+  | "gasoline"
+  | "diesel"
+  | "electric"
+  | "cng"
+  | "lpg"
+  | "hydrogen";
+
+export type RichMode = {
+  value: string;
+  base_mode: string;
+  icon: string;
+  color: string;
+  met?: { [k in string]?: { range: [number, number]; mets: number } };
+  footprint?: {
+    [f in FootprintFuelType]?: {
+      wh_per_km?: number;
+      wh_per_trip?: number;
+    };
+  };
+};
+
+export type MultilabelKey = "MODE" | "PURPOSE" | "REPLACED_MODE";
+
+export type LabelOption<T extends string = MultilabelKey> = T extends "MODE"
+  ? {
+      value: string;
+      base_mode: string;
+    } & Partial<RichMode>
+  : {
+      value: string;
+    };
+
+export type LabelOptionsConfig = {
+  MODE: LabelOption<"MODE">[];
+  PURPOSE: LabelOption<"PURPOSE">[];
+  REPLACED_MODE?: LabelOption<"REPLACED_MODE">[];
+} & {
+  translations: {
+    [lang: string]: { [translationKey: string]: string };
+  };
+};
+
+/* END: label_options types */
 
 export type VehicleIdentity = {
   value: string;

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "op-deployment-configs",
-  "version": "1.0.3"
+  "version": "1.0.4"
 }


### PR DESCRIPTION
#### ✨ Support inline label_options config and add types

> After reworking how the deployment config is handled on the server, label_options gets downloaded and filled in on the server: https://github.com/e-mission/e-mission-server/pull/1088 This means that label_options could be a URL or it could already be filled in, and it should be typed accordingly. These types were previously located in e-mission-phone, but they really should be here since they're part of the deployment config.

<hr>

#### 🔖 1.0.4

<hr>

#### ✅ use ajv-cli for JSON schema validation

> It looks like the GH action `schema-validator-action` is not able to handle the more complex JSON schema that is generated after recent changes to the config spec (namely, types for the label_options field).
> Switching to ajv because it is the standard, and it appears to work testing on all the configs locally