### PR TITLE
💚 Fix js-yaml imports in parse-issue-body script

### DIFF
--- a/.github/actions/convertIssue/parse-issue-body.js
+++ b/.github/actions/convertIssue/parse-issue-body.js
@@ -2,7 +2,7 @@
 
 import { readFile } from "node:fs/promises";
 import { setFailed } from "@actions/core";
-import yaml from "js-yaml";
+import { load } from "js-yaml";
 
 function normalizeNewLines(str) {
   return str.replace(/\r\n/g, "\n");
@@ -43,7 +43,7 @@ function cleanBoolean(str) {
 async function parseFields(githubIssueTemplateFile) {
   try {
     let issueTemplate = await readFile(githubIssueTemplateFile, "utf8");
-    let githubFormData = yaml.load(issueTemplate);
+    let githubFormData = load(issueTemplate);
 
     // Markdown fields aren’t included in output body
     let fields = githubFormData.body.filter(


### PR DESCRIPTION
This broke because js-yaml stopped including a default export in v5; see v4 to v5 notes: https://github.com/nodeca/js-yaml/blob/master/docs/migrate_v4_to_v5.md

In issue-to-json, we run `npm i js-yaml @actions/core @actions/github` which will grab latest packages not pinned to specific versions. If we keep encountering breaking changes in the future we can pin them.